### PR TITLE
Add banner to home page

### DIFF
--- a/code0615/webapp/templates/index.html
+++ b/code0615/webapp/templates/index.html
@@ -48,6 +48,7 @@
     <div id="app" class="container mx-auto px-2 py-4">
         <!-- 游戏模式选择 -->
         <div v-if="!gameStarted && !showSetupModal" class="max-w-md mx-auto bg-white rounded-lg shadow-md p-6">
+            <img src="/static/img/banner.png" alt="Banner" class="mx-auto mb-4">
             <h1 class="text-2xl font-bold mb-4 text-center">狼人杀游戏</h1>
             <div class="space-y-3">
                 <button @click="startAIGame"


### PR DESCRIPTION
## Summary
- show banner.png from static assets on the landing page

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_684e95402af48332bff418f7205a916d